### PR TITLE
Add mutator, width/height, bg color options

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -31,11 +31,13 @@
         return Promise.resolve(node)
             .then(function (node) {
                 return cloneNode(node, options.filter);
+            }).then(function(clone) {
+            	return options.mutate ? options.mutate(clone) : clone;
             })
             .then(embedFonts)
             .then(inlineImages)
             .then(function (clone) {
-                return makeSvgDataUri(clone, node.scrollWidth, node.scrollHeight);
+                return makeSvgDataUri(clone, options.width ? options.width : node.scrollWidth, options.height ? options.height : node.scrollHeight);
             });
     }
 
@@ -228,8 +230,16 @@
             .then(util.delay(100))
             .then(function (image) {
                 var canvas = document.createElement('canvas');
-                canvas.width = domNode.scrollWidth;
-                canvas.height = domNode.scrollHeight;
+                canvas.width = options.width ? options.width : domNode.scrollWidth;
+                canvas.height = options.height ? options.height : domNode.scrollHeight;
+                
+                if(options.bgColor) {
+                    var ctx = canvas.getContext('2d');
+                    ctx.rect(0,0,canvas.width, canvas.height);
+                    ctx.fillStyle=options.bgColor.toUpperCase();
+                    ctx.fill();                	
+                }
+                
                 canvas.getContext('2d').drawImage(image, 0, 0);
                 return canvas;
             });


### PR DESCRIPTION
Hi, and thanks for a cool library! Works really well for my use case of creating a snapshot of a table that can then be copy/pasted documents.

However, in my use case, the table is bigger than the viewport, and it also has an Excel type Freeze Panes functionality, whereby header and sidebar stay in place even if you scroll. Accordingly, in standard configuration you only got what was visible in the viewport.

To work around this I had to add a number of options:
- Mutate function that can be used to do arbitrary transformations to the clone node structure. I used this to get rid of css height, width, and margins in certain nodes
- Explicit height and width for the canvas, as after modifying the clone the computed height and width for the root node are not correct anymore
- Explicit background color, as at least MS Office does not handle transparent background well

With the above I'm able to bake an image of the whole table regardless of viewport size and scrolling that looks nice elsewhere.

This pull request is not so much aimed at merging straight away, but more for discussion on whether the options would make sense for the library.

Let me know what you think.