### PR TITLE
Add support for inlining correct srcset image

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -666,18 +666,20 @@
             };
 
             function inline(get) {
-                if (util.isDataUrl(element.src)) return Promise.resolve();
+                var src = element.currentSrc || element.src;
+                if (util.isDataUrl(src)) return Promise.resolve();
 
-                return Promise.resolve(element.src)
+                return Promise.resolve(src)
                     .then(get || util.getAndEncode)
                     .then(function (data) {
-                        return util.dataAsUrl(data, util.mimeType(element.src));
+                        return util.dataAsUrl(data, util.mimeType(src));
                     })
                     .then(function (dataUrl) {
                         return new Promise(function (resolve, reject) {
                             element.onload = resolve;
                             element.onerror = reject;
                             element.src = dataUrl;
+                            element.srcset = '';
                         });
                     });
             }


### PR DESCRIPTION
Instead of using the image element's `src` to inline the image, this uses the `currentSrc`, which takes into account the `srcset` attribute. And seeing as the `srcset` attribute takes precedence over `src`, this also removes it after the image is inlined.

I ran into this issue while attempting to render `https://bugsnag.com`, multiple images on their homepage include `srcset` attributes, all fail to render correctly without this patch, as the `srcset` attribute caused the inlined `src` to be ignored.