### PR TITLE
fix inline style's width/height

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -505,13 +505,17 @@
         function width(node) {
             var leftBorder = px(node, 'border-left-width');
             var rightBorder = px(node, 'border-right-width');
-            return node.scrollWidth + leftBorder + rightBorder;
+            var boundingWidth = node.getBoundingClientRect().width;
+            var width = (node.scrollWidth || boundingWidth) + leftBorder + rightBorder;
+            return width;
         }
 
         function height(node) {
             var topBorder = px(node, 'border-top-width');
             var bottomBorder = px(node, 'border-bottom-width');
-            return node.scrollHeight + topBorder + bottomBorder;
+            var boundingHeight = node.getBoundingClientRect().height;
+            var height = (node.scrollHeight || boundingHeight) + topBorder + bottomBorder;
+            return height;
         }
 
         function px(node, styleProperty) {


### PR DESCRIPTION
Hi, and thanks for your great work here, works really well for my use case of screenshot, but i found a small problem with element's style=`display:inline` can cause error on chrome, because of `width/height = 0` and i try to solve this problem using `element.getBoundingClientRect()` to fetch `boudingWidth/boudingHeight` when `scrollWidth/scrollHeight = 0`