### PR TITLE
Handle #94 Add option to ignore image errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ for JavaScript names of CSS properties.
 A number between 0 and 1 indicating image quality (e.g. 0.92 => 92%) of the
 JPEG image. Defaults to 1.0 (100%)
 
+#### ignoreImageErrors
+
+Disregard errors when images fail to load and continue to render.
+
 ## Browsers
 
 It's tested on latest Chrome and Firefox (49 and 45 respectively at the time


### PR DESCRIPTION
Provide `ignoreImageErrors` option, which continues the render process regardless of individual images failing to load.