### PR TITLE
Add cache bypass because CORS headers are missing on a cache hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ JPEG image. Defaults to 1.0 (100%)
 
 #### cacheBust
 
-Set to true to append the current time as a query string to URL requests to enable cache busting. Defaults to true
+Set to true to append the current time as a query string to URL requests to enable cache busting. Defaults to false
 
-#### placeholder
+#### imagePlaceholder
 
-A data URL for a placeholder image that will be used when fetching an image fails. Defaults to grey 1x1 image
+A data URL for a placeholder image that will be used when fetching an image fails. Defaults to undefined and will throw an error on failed images
 
 ## Browsers
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ for JavaScript names of CSS properties.
 A number between 0 and 1 indicating image quality (e.g. 0.92 => 92%) of the
 JPEG image. Defaults to 1.0 (100%)
 
+#### cacheBust
+
+Set to true to append the current time as a query string to URL requests to enable cache busting. Defaults to true
+
+#### placeholder
+
+A data URL for a placeholder image that will be used when fetching an image fails. Defaults to grey 1x1 image
+
 ## Browsers
 
 It's tested on latest Chrome and Firefox (49 and 45 respectively at the time

--- a/spec/dom-to-image.spec.js
+++ b/spec/dom-to-image.spec.js
@@ -496,10 +496,21 @@
                     .then(done).catch(done);
             });
 
-            it('should return empty result if cannot get resourse', function (done) {
+            it('should return placeholder result if cannot get resource', function (done) {
+                domtoimage.impl.util.getAndEncode(BASE_URL + 'util/not-found')
+                    .then(function (resource) {
+                        var placeholderData = domtoimage.impl.options.placeholder.split(/,/)[1];
+                        assert.equal(resource, placeholderData);
+                    }).then(done).catch(done);
+            });
+
+            it('should return empty result if cannot get resource and placeholder set to undefined', function (done) {
+                var original = domtoimage.impl.options.placeholder;
+                domtoimage.impl.options.placeholder = undefined;
                 domtoimage.impl.util.getAndEncode(BASE_URL + 'util/not-found')
                     .then(function (resource) {
                         assert.equal(resource, '');
+                        domtoimage.impl.options.placeholder = original;
                     }).then(done).catch(done);
             });
 

--- a/spec/dom-to-image.spec.js
+++ b/spec/dom-to-image.spec.js
@@ -496,21 +496,22 @@
                     .then(done).catch(done);
             });
 
-            it('should return placeholder result if cannot get resource', function (done) {
-                domtoimage.impl.util.getAndEncode(BASE_URL + 'util/not-found')
-                    .then(function (resource) {
-                        var placeholderData = domtoimage.impl.options.placeholder.split(/,/)[1];
-                        assert.equal(resource, placeholderData);
-                    }).then(done).catch(done);
-            });
-
-            it('should return empty result if cannot get resource and placeholder set to undefined', function (done) {
-                var original = domtoimage.impl.options.placeholder;
-                domtoimage.impl.options.placeholder = undefined;
+            it('should return empty result if cannot get resource', function (done) {
                 domtoimage.impl.util.getAndEncode(BASE_URL + 'util/not-found')
                     .then(function (resource) {
                         assert.equal(resource, '');
-                        domtoimage.impl.options.placeholder = original;
+                    }).then(done).catch(done);
+            });
+
+            it('should return placeholder result if cannot get resource and placeholder is provided', function (done) {
+                var placeholder = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY7h79y4ABTICmGnXPbMAAAAASUVORK5CYII=";
+                var original = domtoimage.impl.options.imagePlaceholder;
+                domtoimage.impl.options.imagePlaceholder = placeholder;
+                domtoimage.impl.util.getAndEncode(BASE_URL + 'util/not-found')
+                    .then(function (resource) {
+                        var placeholderData = placeholder.split(/,/)[1];
+                        assert.equal(resource, placeholderData);
+                        domtoimage.impl.options.imagePlaceholder = original;
                     }).then(done).catch(done);
             });
 

--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -117,7 +117,8 @@
      * @return {Promise} - A promise that is fulfilled with a JPEG image data URL
      * */
     function toJpeg(node, options) {
-        return draw(node, options || {})
+        options = options || {};
+        return draw(node, options)
             .then(function (canvas) {
                 return canvas.toDataURL('image/jpeg', options.quality || 1.0);
             });

--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -480,8 +480,8 @@
                 var placeholder;
                 if(domtoimage.impl.options.placeholder) {
                     var split = domtoimage.impl.options.placeholder.split(/,/);
-                    if(split[0]) {
-                        placeholder = split[0];
+                    if(split && split[1]) {
+                        placeholder = split[1];
                     }
                 }
 

--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -491,8 +491,7 @@
                     if (request.status !== 200) {
                         if(placeholder) {
                             resolve(placeholder);
-                        }
-                        else {
+                        } else {
                             fail('cannot fetch resource: ' + url + ', status: ' + request.status);
                         }
 
@@ -510,8 +509,7 @@
                 function timeout() {
                     if(placeholder) {
                         resolve(placeholder);
-                    }
-                    else {
+                    } else {
                         fail('timeout of ' + TIMEOUT + 'ms occured while fetching resource: ' + url);
                     }
                 }

--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -435,6 +435,9 @@
 
         function getAndEncode(url) {
             var TIMEOUT = 30000;
+            // Cache bypass so we dont have CORS issues with cached images
+            // Source: https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache
+            url += ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
 
             return new Promise(function (resolve) {
                 var request = new XMLHttpRequest();

--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -6,6 +6,14 @@
     var fontFaces = newFontFaces();
     var images = newImages();
 
+    // Default impl options
+    var defaultOptions = {
+        // Default placeholder is a 1x1 gray square
+        placeholder: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY7h79y4ABTICmGnXPbMAAAAASUVORK5CYII=",
+        // Default cache bust is true
+        cacheBust: true
+    };
+
     var domtoimage = {
         toSvg: toSvg,
         toPng: toPng,
@@ -16,7 +24,8 @@
             fontFaces: fontFaces,
             images: images,
             util: util,
-            inliner: inliner
+            inliner: inliner,
+            options: {}
         }
     };
 
@@ -37,10 +46,13 @@
      * @param {Object} options.style - an object whose properties to be copied to node's style before rendering.
      * @param {Number} options.quality - a Number between 0 and 1 indicating image quality (applicable to JPEG only),
                 defaults to 1.0.
+     * @param {String} options.placeholder - dataURL to use as a placeholder for failed images, pass null to fail fast on images we can't fetch
+     * @param {Boolean} options.cacheBust - set to true to cache bust by appending the time to the request url
      * @return {Promise} - A promise that is fulfilled with a SVG image data URL
      * */
     function toSvg(node, options) {
         options = options || {};
+        copyOptions(options);
         return Promise.resolve(node)
             .then(function (node) {
                 return cloneNode(node, options.filter, true);
@@ -105,7 +117,6 @@
      * @return {Promise} - A promise that is fulfilled with a JPEG image data URL
      * */
     function toJpeg(node, options) {
-        options = options || {};
         return draw(node, options)
             .then(function (canvas) {
                 return canvas.toDataURL('image/jpeg', options.quality || 1.0);
@@ -120,6 +131,21 @@
     function toBlob(node, options) {
         return draw(node, options || {})
             .then(util.canvasToBlob);
+    }
+
+    function copyOptions(options) {
+        // Copy options to impl options for use in impl
+        if(typeof(options.placeholder) === 'undefined') {
+            domtoimage.impl.options.placeholder = defaultOptions.placeholder;
+        } else {
+            domtoimage.impl.options.placeholder = options.placeholder;
+        }
+
+        if(typeof(options.cacheBust) === 'undefined') {
+            domtoimage.impl.options.cacheBust = defaultOptions.cacheBust;
+        } else {
+            domtoimage.impl.options.cacheBust = options.cacheBust;
+        }
     }
 
     function draw(domNode, options) {
@@ -435,9 +461,11 @@
 
         function getAndEncode(url) {
             var TIMEOUT = 30000;
-            // Cache bypass so we dont have CORS issues with cached images
-            // Source: https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache
-            url += ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
+            if(domtoimage.impl.options.cacheBust) {
+                // Cache bypass so we dont have CORS issues with cached images
+                // Source: https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache
+                url += ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
+            }
 
             return new Promise(function (resolve) {
                 var request = new XMLHttpRequest();
@@ -449,11 +477,25 @@
                 request.open('GET', url, true);
                 request.send();
 
+                var placeholder;
+                if(domtoimage.impl.options.placeholder) {
+                    var split = domtoimage.impl.options.placeholder.split(/,/);
+                    if(split[0]) {
+                        placeholder = split[0];
+                    }
+                }
+
                 function done() {
                     if (request.readyState !== 4) return;
 
                     if (request.status !== 200) {
-                        fail('cannot fetch resource: ' + url + ', status: ' + request.status);
+                        if(placeholder) {
+                            resolve(placeholder);
+                        }
+                        else {
+                            fail('cannot fetch resource: ' + url + ', status: ' + request.status);
+                        }
+
                         return;
                     }
 
@@ -466,7 +508,12 @@
                 }
 
                 function timeout() {
-                    fail('timeout of ' + TIMEOUT + 'ms occured while fetching resource: ' + url);
+                    if(placeholder) {
+                        resolve(placeholder);
+                    }
+                    else {
+                        fail('timeout of ' + TIMEOUT + 'ms occured while fetching resource: ' + url);
+                    }
                 }
 
                 function fail(message) {

--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -8,10 +8,10 @@
 
     // Default impl options
     var defaultOptions = {
-        // Default placeholder is a 1x1 gray square
-        placeholder: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY7h79y4ABTICmGnXPbMAAAAASUVORK5CYII=",
-        // Default cache bust is true
-        cacheBust: true
+        // Default is to fail on error, no placeholder
+        imagePlaceholder: undefined,
+        // Default cache bust is false, it will use the cache
+        cacheBust: false
     };
 
     var domtoimage = {
@@ -46,7 +46,7 @@
      * @param {Object} options.style - an object whose properties to be copied to node's style before rendering.
      * @param {Number} options.quality - a Number between 0 and 1 indicating image quality (applicable to JPEG only),
                 defaults to 1.0.
-     * @param {String} options.placeholder - dataURL to use as a placeholder for failed images, pass null to fail fast on images we can't fetch
+     * @param {String} options.imagePlaceholder - dataURL to use as a placeholder for failed images, default behaviour is to fail fast on images we can't fetch
      * @param {Boolean} options.cacheBust - set to true to cache bust by appending the time to the request url
      * @return {Promise} - A promise that is fulfilled with a SVG image data URL
      * */
@@ -136,10 +136,10 @@
 
     function copyOptions(options) {
         // Copy options to impl options for use in impl
-        if(typeof(options.placeholder) === 'undefined') {
-            domtoimage.impl.options.placeholder = defaultOptions.placeholder;
+        if(typeof(options.imagePlaceholder) === 'undefined') {
+            domtoimage.impl.options.imagePlaceholder = defaultOptions.imagePlaceholder;
         } else {
-            domtoimage.impl.options.placeholder = options.placeholder;
+            domtoimage.impl.options.imagePlaceholder = options.imagePlaceholder;
         }
 
         if(typeof(options.cacheBust) === 'undefined') {
@@ -479,8 +479,8 @@
                 request.send();
 
                 var placeholder;
-                if(domtoimage.impl.options.placeholder) {
-                    var split = domtoimage.impl.options.placeholder.split(/,/);
+                if(domtoimage.impl.options.imagePlaceholder) {
+                    var split = domtoimage.impl.options.imagePlaceholder.split(/,/);
                     if(split && split[1]) {
                         placeholder = split[1];
                     }

--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -117,7 +117,7 @@
      * @return {Promise} - A promise that is fulfilled with a JPEG image data URL
      * */
     function toJpeg(node, options) {
-        return draw(node, options)
+        return draw(node, options || {})
             .then(function (canvas) {
                 return canvas.toDataURL('image/jpeg', options.quality || 1.0);
             });


### PR DESCRIPTION
This fixes all my CORS issues. It does not add CORS where it did not exist previously though.
What was happening in my case was my html loaded the images before dom-to-image was being run, this caused the images to be cached with incorrect CORS headers, thus when dom-to-image requested the image and hit the cache it would taint the canvas and render the functionality useless.