### PR TITLE
toCanvas returns a promise that is fulfilled with a canvas object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ domtoimage.toPixelData(node)
     });
 ```
 
+Get a canvas object:
+
+```javascript
+domtoimage.toCanvas(document.getElementById('my-node'))
+    .then(function (canvas) {
+        console.log('canvas', canvas.width, canvas.height);
+    });
+```
+
 * * *
 
 _All the functions under `impl` are not public API and are exposed only

--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -20,6 +20,7 @@
         toJpeg: toJpeg,
         toBlob: toBlob,
         toPixelData: toPixelData,
+        toCanvas: toCanvas,
         impl: {
             fontFaces: fontFaces,
             images: images,
@@ -132,6 +133,15 @@
     function toBlob(node, options) {
         return draw(node, options || {})
             .then(util.canvasToBlob);
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a canvas object
+     * */
+    function toCanvas(node, options) {
+        return draw(node, options || {});
     }
 
     function copyOptions(options) {


### PR DESCRIPTION
This exposes the result of the `draw` function while making sure that there is an `options` object.  I wrote this to satisfy #138.

While testing my change, I noticed unexpected results if the DOM node has a margin (e.g., `p` without an additional style).  The margin isn't included when sizing the canvas but the content is drawn in the canvas offset by the margin.  It would be good to mention this in the documentation if it cannot be fixed easily.