### PR TITLE
hotfix: copyStyle func fix for some elements

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -231,8 +231,22 @@
                 copyStyle(window.getComputedStyle(original), clone.style);
 
                 function copyStyle(source, target) {
-                    if (source.cssText) target.cssText = source.cssText;
-                    else copyProperties(source, target);
+                    if (source.cssText) {
+                        // This is fix for some elements with 100% width and height,
+                        // because "auto" is not good when make image
+                        var cssText = source.cssText;
+                        if (target.width == "100%") {
+                            cssText = cssText.replace("width: auto; ", "");
+                        }
+                        if (target.height == "100%") {
+                            cssText = cssText.replace("height: auto; ", "");
+                        }
+
+                        target.cssText = cssText;
+
+                    } else {
+                        copyProperties(source, target);
+                    }
 
                     function copyProperties(source, target) {
                         util.asArray(source).forEach(function (name) {


### PR DESCRIPTION
Hi!
First of all, thanks for your library. It's cool!

Recently i made my [own project](http://wooden-tiles.ru/) and used dom-to-image to create PNG from tiles with SVG, base64 and masks.
Maybe i was doing something wrong, but created images was broken. I figured out a problem. In my case, it was in copyStyle function.

I recreated a problem here: https://codepen.io/unfriend/pen/ddEaqL