### PR TITLE
fixes #78 - encodes uris for edge to accept svg+xml data uris

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -456,7 +456,7 @@
                     resolve(image);
                 };
                 image.onerror = reject;
-                image.src = uri;
+                image.src = encodeURI(uri);
             });
         }
 


### PR DESCRIPTION
The final svg+xml data uri looks something like this "'data:image/svg+xml;charset=utf8,<svg ...> ... </svg>'"  which causes Edge to throw an error during image loading due to some of the characters like '<' and '>'. 

Simple fix is to wrap the uri with encodeURI.

More detail can be found here https://codepen.io/tigt/post/optimizing-svgs-in-data-uris however this fix doesn't do any of the extra work to convert other characters, which I don't think is really necessary here.
