### PR TITLE
Understanding images links as http://domain.com/download?img=picture.…

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -388,7 +388,7 @@
 
         function parseExtension(url) {
             var match = /\.([^\.\/]*?)$/g.exec(url);
-            if (match) return match[1];
+            if (match) return match[1].split(/&/)[0];
             else return '';
         }
 


### PR DESCRIPTION
Understanding images links as http://domain.com/download?img=picture.png&key=value

Previously, `&` was getting broken the mimeType recognizing.