### PR TITLE
fix for Failed to read the 'cssRules' property from 'CSSStyleSheet':

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -678,10 +678,12 @@
             function getCssRules(styleSheets) {
                 var cssRules = [];
                 styleSheets.forEach(function (sheet) {
-                    try {
-                        util.asArray(sheet.cssRules || []).forEach(cssRules.push.bind(cssRules));
-                    } catch (e) {
-                        console.log('Error while reading CSS rules from ' + sheet.href, e.toString());
+                    if (sheet.hasOwnProperty("cssRules")) {
+                        try {
+                            util.asArray(sheet.cssRules || []).forEach(cssRules.push.bind(cssRules));
+                        } catch (e) {
+                            console.log('Error while reading CSS rules from ' + sheet.href, e.toString());
+                        }
                     }
                 });
                 return cssRules;


### PR DESCRIPTION
As per: https://github.com/tsayen/dom-to-image/issues/210