### PR TITLE
ci: use new Chrome and Firefox addons in headless mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 dist: trusty
+env:
+  - MOZ_HEADLESS=1
 addons:
-    firefox: "49.0"
+  chrome: stable
+  firefox: latest
+
 language: node_js
-before_install:
-    - sudo apt-get update -q
-    - sudo apt-get install chromium-browser -y
 before_script:
-    - export CHROME_BIN=chromium-browser
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
+    - sleep 3 # give xvfb some time to start


### PR DESCRIPTION
Try the new Chrome and Firefox addons in headless mode.