### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 addons:
     firefox: "49.0"
 language: node_js
+node_js:
+    - "node"
+    - "10"
+    - "8"
+    - "6"
 before_install:
     - sudo apt-get update -q
     - sudo apt-get install chromium-browser -y


### PR DESCRIPTION
Currently Node.js 0.10 is used for the CI which is very old and has already reached its EOL.

We should test against all current LTS and stable branches of Node.js.