### PR TITLE
fix: Capture the url type error

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -387,7 +387,7 @@
         }
 
         function parseExtension(url) {
-            var match = /\.([^\.\/]*?)$/g.exec(url);
+            var match = /\.([^\.\/]*?)(\?|$)/g.exec(url);
             if (match) return match[1];
             else return '';
         }


### PR DESCRIPTION
if the url is like: 
'https://www.xxx.com/chem/test/11ff1508-0af7-7b6a-2cd4-70220d09af23.svg?75d126a1-21ab-4021-c6c4-13625372c042'
that will return 'svg?75d126a1-21ab-4021-c6c4-13625372c042',  not 'svg'