### PR TITLE
Removing margin on clone of root node

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -229,6 +229,11 @@
 
             function cloneStyle() {
                 copyStyle(window.getComputedStyle(original), clone.style);
+                
+                // Prevent cropping and gaps at edge of element
+                if (root) {
+                    clone.style.setProperty('margin', 0);
+                }
 
                 function copyStyle(source, target) {
                     if (source.cssText) target.cssText = source.cssText;


### PR DESCRIPTION
This makes it so that elements with negative margin are not cropped by the SVG