### PR TITLE
Support replacing node when filter

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -175,7 +175,17 @@
     }
 
     function cloneNode(node, filter, root) {
-        if (!root && filter && !filter(node)) return Promise.resolve();
+        if (!root && filter) {
+            const filterRet = filter(node)
+            if (!filterRet) {
+                // false or undefined or null
+                return Promise.resolve();
+            }
+
+            // if filter returns boolean true, keep node unchanged
+            // else we use filter result as template node to clone
+            node = filterRet === true ? node : filterRet;
+        }
 
         return Promise.resolve(node)
             .then(makeNodeCopy)


### PR DESCRIPTION
This pull request introduce supporting for replacing node when doing filter.

The original demand is to use first frame of video instead of blank(transparent) when capturing a node.

See what it can do :

Assuming that we have a node:

```html
<div>
   <p>Hello Video</p>
   <video src='http://mock.video.addr.com/1.mp4'></video>
</div>
```

A regular call to `domtoimage.toPng(theDiv)` would result to a image only contain the 'Hello world' text, leave blank for video area.

Now you can do:

```js
const convertVideoToCanvas = (node)=>{
  if (node instanceof HTMLVideoElement) {
    const c = document.createElement('canvas');
    c.width = node.clientWidth;
    c.height = node.clientHeight;
    c.setAttribute('style', c.getAttribute('style') || '')
    const ctx = c.getContext('2d');
    if (ctx) {
      if (node.readyState >= 3) {
        ctx.drawImage(node, 0, 0);
      }
    }
    return c;
  }
  return node
}
const options = {
  filter: convertVideoToCanvas
}
domtoimage.toPng(theDiv, option)
```

This will create a image contains both text and video.

And you can do other similar node replacing trick.

On the other hand, this patch keep the api compatibility of `filter` unchanged.

So you can still do `boolean` filter like you always do:

```js
const option = {
  filter: (node)=>{return node.nodeName !== 'video'}
}
``` 