### PR TITLE
Fixed bug applying clasName to SVG DOM tags

### DIFF
--- a/src/dom-to-image.js
+++ b/src/dom-to-image.js
@@ -258,7 +258,7 @@
                     if (content === '' || content === 'none') return;
 
                     var className = util.uid();
-                    clone.className = clone.className + ' ' + className;
+                    clone.setAttribute('class', clone.className + ' ' + className)
                     var styleElement = document.createElement('style');
                     styleElement.appendChild(formatPseudoElementStyle(className, element, style));
                     clone.appendChild(styleElement);


### PR DESCRIPTION
Setting className = throwed this error: 

Cannot set property className of SVGElement which has only a getter.

Setting this line to node.setAttribute fixed the error